### PR TITLE
fix : some POST requests could be sent with header Content-Type=application/x-www-form-urlencoded

### DIFF
--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -148,8 +148,11 @@ const content = [
       },
       {
         question: "J'ai payé ma place, puis-je encore changer de tournoi ?",
-        answer:
-          'Oui, la place payée est rattachée à un compte et non à un tournoi. Il est donc possible de changer de tournoi sans payer à nouveau, sauf pour le tournoi Super Smash Bros Ultimate.',
+        answer: (
+          <>
+            Oui, c'est possible. Contacte-nous via le <a href="/contact">formulaire de contact</a>.
+          </>
+        ),
       },
     ],
   },

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -20,6 +20,7 @@ const requestAPI = (method, baseURL, route, authorizationHeader, body = null, di
         url: route + (disableCache ? '?nocache=' + new Date().getTime() : ''),
         data: body,
         timeout: 5000,
+        'Content-Type': 'application/json'
       })
       // Success
       .then((response) => resolve(response))
@@ -43,9 +44,9 @@ export const setAuthorizationToken = (_token) => {
 // Access the API through different HTTP methods
 export const API = {
   get: (route) => requestAPI('GET', apiUrl(), route, true),
-  post: (route, body = {}) => requestAPI('POST', apiUrl(), route, true, body),
-  put: (route, body = {}) => requestAPI('PUT', apiUrl(), route, true, body),
-  patch: (route, body = {}) => requestAPI('PATCH', apiUrl(), route, true, body),
+  post: (route, body) => requestAPI('POST', apiUrl(), route, true, body),
+  put: (route, body) => requestAPI('PUT', apiUrl(), route, true, body),
+  patch: (route, body) => requestAPI('PATCH', apiUrl(), route, true, body),
   delete: (route) => requestAPI('DELETE', apiUrl(), route, true),
 };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -43,9 +43,9 @@ export const setAuthorizationToken = (_token) => {
 // Access the API through different HTTP methods
 export const API = {
   get: (route) => requestAPI('GET', apiUrl(), route, true),
-  post: (route, body) => requestAPI('POST', apiUrl(), route, true, body),
-  put: (route, body) => requestAPI('PUT', apiUrl(), route, true, body),
-  patch: (route, body) => requestAPI('PATCH', apiUrl(), route, true, body),
+  post: (route, body = {}) => requestAPI('POST', apiUrl(), route, true, body),
+  put: (route, body = {}) => requestAPI('PUT', apiUrl(), route, true, body),
+  patch: (route, body = {}) => requestAPI('PATCH', apiUrl(), route, true, body),
   delete: (route) => requestAPI('DELETE', apiUrl(), route, true),
 };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -20,7 +20,7 @@ const requestAPI = (method, baseURL, route, authorizationHeader, body = null, di
         url: route + (disableCache ? '?nocache=' + new Date().getTime() : ''),
         data: body,
         timeout: 5000,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       })
       // Success
       .then((response) => resolve(response))


### PR DESCRIPTION
The bug was due to the fact that nothing was sent. We should at least send an empty object in methods POST, PATCH and PUT.
Now body of request methods POST, PATCH and PUT is defaulted to an empty object in the api.js file