### PR TITLE
fix: ids now have clean names

### DIFF
--- a/src/app/(dashboard)/admin/badge/page.tsx
+++ b/src/app/(dashboard)/admin/badge/page.tsx
@@ -37,7 +37,7 @@ export default function BadgePage() {
   document.documentElement.style.setProperty('--half-size', crop ? `${crop.width / 2}px` : '0px');
 
   return (
-    <div id={styles.badgePage}>
+    <div id="badge-page" className={styles.badgePage}>
       <FileUpload
         label="La photo sur ton badge"
         value={'test'}

--- a/src/app/(dashboard)/admin/badge/style.module.scss
+++ b/src/app/(dashboard)/admin/badge/style.module.scss
@@ -1,4 +1,4 @@
-#badgePage {
+.badgePage {
   display: flex;
   gap: 10px;
 

--- a/src/app/(dashboard)/admin/scan/page.tsx
+++ b/src/app/(dashboard)/admin/scan/page.tsx
@@ -24,7 +24,7 @@ const Entry = () => {
   };
 
   return (
-    <div id={styles.adminEntry}>
+    <div id="admin-entry" className={styles.adminEntry}>
       <div className={styles.scan}>
         <Title level={2} type={2}>
           Scanner une place

--- a/src/app/(dashboard)/admin/scan/style.module.scss
+++ b/src/app/(dashboard)/admin/scan/style.module.scss
@@ -1,4 +1,4 @@
-#adminEntry {
+.adminEntry {
   padding-bottom: 20px;
   margin-bottom: 30px;
   text-align: left;

--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -123,7 +123,7 @@ const Users = () => {
   };
 
   return (
-    <div id={styles.adminUser}>
+    <div id="admin-user" className={styles.adminUser}>
       {isAdmin && (
         <div className={styles.rowAddButton}>
           <Title level={3} type={1} className={styles.userTitle}>

--- a/src/app/(dashboard)/admin/users/style.module.scss
+++ b/src/app/(dashboard)/admin/users/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#adminUser {
+.adminUser {
   padding: 60px;
 
   .rowAddButton {
@@ -87,7 +87,7 @@
 
 }
 @media screen and (max-width: 1024px) {
-    #adminUser {
+    .adminUser {
       .rowAddButton {
         display: flex;
         flex-flow: column;

--- a/src/app/(dashboard)/dashboard/account/page.tsx
+++ b/src/app/(dashboard)/dashboard/account/page.tsx
@@ -82,7 +82,7 @@ const Account = () => {
   };
 
   return (
-    <div id={styles.dashboardAccount}>
+    <div id="dashboard-account" className={styles.dashboardAccount}>
       <div className={styles.infos}>
         <Title level={4}>Mes informations</Title>
 

--- a/src/app/(dashboard)/dashboard/account/style.module.scss
+++ b/src/app/(dashboard)/dashboard/account/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#dashboardAccount {
+.dashboardAccount {
   display: flex;
   flex-flow: row wrap;
   justify-content: left;

--- a/src/app/(dashboard)/dashboard/purchases/page.tsx
+++ b/src/app/(dashboard)/dashboard/purchases/page.tsx
@@ -89,7 +89,11 @@ const Purchases = () => {
         );
       });
 
-  return <div id={styles.dashboardPurchases}>{carts.length ? displayCarts : <Title level={4}>Aucun achat</Title>}</div>;
+  return (
+    <div id="dashboard-purchases" className={styles.dashboardPurchases}>
+      {carts.length ? displayCarts : <Title level={4}>Aucun achat</Title>}
+    </div>
+  );
 };
 
 export default Purchases;

--- a/src/app/(dashboard)/dashboard/purchases/style.module.scss
+++ b/src/app/(dashboard)/dashboard/purchases/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#dashboardPurchases {
+.dashboardPurchases {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;

--- a/src/app/(dashboard)/dashboard/register/page.tsx
+++ b/src/app/(dashboard)/dashboard/register/page.tsx
@@ -327,7 +327,11 @@ const Register = () => {
     );
   };
 
-  return <div id="dashboard-register" className={styles.dashboardRegister}>{Stepper()}</div>;
+  return (
+    <div id="dashboard-register" className={styles.dashboardRegister}>
+      {Stepper()}
+    </div>
+  );
 };
 
 export default Register;

--- a/src/app/(dashboard)/dashboard/register/page.tsx
+++ b/src/app/(dashboard)/dashboard/register/page.tsx
@@ -327,7 +327,7 @@ const Register = () => {
     );
   };
 
-  return <div id={styles.dashboardRegister}>{Stepper()}</div>;
+  return <div id="dashboard-register" className={styles.dashboardRegister}>{Stepper()}</div>;
 };
 
 export default Register;

--- a/src/app/(dashboard)/dashboard/register/style.module.scss
+++ b/src/app/(dashboard)/dashboard/register/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#dashboardRegister {
+.dashboardRegister {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -145,7 +145,7 @@
 }
 
 @media screen and (max-width: 1200px) {
-  #dashboardRegister {
+  .dashboardRegister {
     .teamTournament > div,
     .joinSolo > div {
       width: 100%;

--- a/src/app/(dashboard)/dashboard/shop/page.tsx
+++ b/src/app/(dashboard)/dashboard/shop/page.tsx
@@ -295,7 +295,7 @@ const Shop = () => {
   };
 
   return (
-    <div id={styles.dashboardShop}>
+    <div id="dashboard-shop" className={styles.dashboardShop}>
       <div className={styles.shopAndBill}>
         <div>
           <div className={styles.shopSection}>

--- a/src/app/(dashboard)/dashboard/shop/style.module.scss
+++ b/src/app/(dashboard)/dashboard/shop/style.module.scss
@@ -1,4 +1,4 @@
-#dashboardShop {
+.dashboardShop {
   .shopAndBill {
     display: flex;
     flex-direction: row;
@@ -61,7 +61,7 @@
 }
 
 @media screen and (max-width: 1600px) {
-  #dashboardShop .shopAndBill {
+  .dashboardShop .shopAndBill {
     flex-direction: column;
     .bill {
       width: 100%;

--- a/src/app/(dashboard)/dashboard/team/style.module.scss
+++ b/src/app/(dashboard)/dashboard/team/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#dashboardTeam {
+.dashboardTeam {
   .tablePlayers {
     width: 100%;
     margin-bottom: 30px;
@@ -100,19 +100,19 @@
 }
 
 @media screen and (max-width: 1300px) {
-  #dashboardTeam .teamMatch {
+  .dashboardTeam .teamMatch {
     width: calc(100% / 3 - 20px);
   }
 }
 
 @media screen and (max-width: 1100px) {
-  #dashboardTeam .teamMatch {
+  .dashboardTeam .teamMatch {
     width: calc(50% - 20px);
   }
 }
 
 @media screen and (max-width: 600px) {
-  #dashboardTeam .teamMatch {
+  .dashboardTeam .teamMatch {
     width: 100%;
   }
 }

--- a/src/app/(dashboard)/dashboard/team/team.tsx
+++ b/src/app/(dashboard)/dashboard/team/team.tsx
@@ -268,7 +268,7 @@ const Team = () => {
   }
 
   return (
-    <div id={styles.dashboardTeam}>
+    <div id="dashboard-team" className={styles.dashboardTeam}>
       <div className={styles.header}>
         <div className={styles.headerInfo}>
           {!isSolo && (

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
-      <div id={styles.eventPage}>
+      <div id="event-page" className={styles.eventPage}>
         <Title level={1} className={styles.primaryTitle}>
           Événement
         </Title>

--- a/src/app/event/style.module.scss
+++ b/src/app/event/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#eventPage {
+.eventPage {
   margin-bottom: 10rem;
 
   .primaryTitle {
@@ -110,7 +110,7 @@
 }
 
 @media screen and (max-width: 1024px) {
-  #eventPage {
+  .eventPage {
     .textAndImage {
       flex-direction: column;
       gap: 1.5rem;

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 };
 
 const Legal = () => (
-  <div id={styles.legal}>
+  <div id="legal" className={styles.legal}>
     <div className={styles.container}>
       <Title level={1} type={1} align="center">
         Mentions légales

--- a/src/app/legal/style.module.scss
+++ b/src/app/legal/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#legal {
+.legal {
   .container {
     width: clamp(350px, 80%, 1920px);
     margin: 0 auto;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,7 +6,7 @@ import { Title, Button } from '@/components/UI';
 export default function NotFound() {
   return (
     <>
-      <div id={styles.notFound}>
+      <div id="not-found" className={styles.notFound}>
         <Title level={1} type={1} align="center">
           Page introuvable
         </Title>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ import TournamentList from '@/components/landing/TournamentList';
 
 const Home = () => {
   return (
-    <div id={styles.home}>
+    <div id="home" className={styles.home}>
       <Parallax className={styles.parallax}>
         <ParallaxElementSettings speed={2.6} className={styles.parallaxCloud1}>
           <img src={parallaxCloud1.src} alt="background" />
@@ -45,7 +45,7 @@ const Home = () => {
         className={styles.slider}
         slides={[
           <div key={'slide-1'} className={styles.homeHeader}>
-            <div id={styles.logo}>
+            <div id="logo" className={styles.logo}>
               <img src="/images/logo-notext.png" alt="Logo" />
             </div>
             <div className={styles.homeTitle}>

--- a/src/app/style.module.scss
+++ b/src/app/style.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#home {
+.home {
   position: relative;
   display: flex;
   justify-content: center;
@@ -74,7 +74,7 @@
         position: absolute;
       }
 
-      #logo {
+      .logo {
         max-height: 40%;
         max-width: 60%;
         margin: 0 auto;
@@ -226,7 +226,7 @@
 }
 
 @media screen and (max-width: 1200px) {
-  #home {
+  .home {
     .slider {
       .videoContainer {
         width: 100%;
@@ -236,7 +236,7 @@
 }
 
 @media screen and (max-width: 1024px) {
-  #home {
+  .home {
     .slider {
       .homeHeader {
         .homeTitle {
@@ -278,7 +278,7 @@
 }
 
 @media screen and (max-width: 700px) {
-  #home {
+  .home {
     .slider {
       .homeHeader {
         .homeTitle {

--- a/src/app/tournaments/layout.module.scss
+++ b/src/app/tournaments/layout.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#tournamentLayout {
+.tournamentLayout {
   .topContainer {
     background-color: $primary-background;
     padding: 100px 0 100px 0;
@@ -129,7 +129,7 @@
 }
 
 @media screen and (max-width: 1024px) {
-  #tournamentLayout {
+  .tournamentLayout {
     .topContainer {
       .top {
         width: 80%;

--- a/src/app/tournaments/layout.tsx
+++ b/src/app/tournaments/layout.tsx
@@ -24,7 +24,7 @@ const TournamentsLayout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
   const pathname = usePathname();
   return (
-    <div id={styles.tournamentLayout}>
+    <div id="tournament-layout" className={styles.tournamentLayout}>
       <div className={styles.topContainer}>
         <div className={styles.top}>
           <Title level={3} type={1} align={'center'}>

--- a/src/components/CookieConsent.module.scss
+++ b/src/components/CookieConsent.module.scss
@@ -1,4 +1,4 @@
-#cookieConsent {
+.cookieConsent {
   position: fixed;
   right: 20px;
   bottom: 20px;
@@ -28,7 +28,7 @@
 }
 
 @media screen and (max-width: 650px) {
-  #cookieConsent {
+  .cookieConsent {
     width: 100%;
     padding: 10px;
     left: 0;
@@ -37,7 +37,7 @@
 }
 
 @media screen and (max-width: 350px) {
-  #cookieButton {
+  .cookieButton {
     width: 100%;
   }
 }

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -39,7 +39,7 @@ export default function CookieConsent({
   }
 
   return (
-    <div id={styles.cookieConsent}>
+    <div id="cookie-content" className={styles.cookieConsent}>
       Nous utilisons les cookies pour proposer et améliorer nos services. En appuyant sur J'accepte, tu consens
       {' à'} l'utilisation de ces cookies. <Link href="/legal">En&nbsp;savoir&nbsp;plus</Link>
       <br />

--- a/src/components/Footer.module.scss
+++ b/src/components/Footer.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#footer {
+.footer {
   background-color: $secondary-background;
   padding-bottom: 20px;
   overflow: hidden;
@@ -111,7 +111,7 @@
 
   .middle {
     display: block;
-    
+
     button {
       padding-left: 0;
     }
@@ -149,7 +149,7 @@
 }
 
 @media screen and (max-width: 1024px) {
-  #footer {
+  .footer {
     .row {
       align-items: center;
       flex-direction: column;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,7 +14,7 @@ import { IconName } from './UI/Icon';
 export default function Footer() {
   const [copyrightTurned, setCopyrightTurned] = useState(false);
   return (
-    <footer id={styles.footer}>
+    <footer id="footer" className={styles.footer}>
       <div className={styles.row}>
         <div>
           <img src={logo.src} alt="Logo UA23" />

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -7,7 +7,7 @@ $scrollingAnimationDuration: 0.5s;
   top: 20px;
 }
 
-#header {
+.header {
   height: 100px;
   background-color: $secondary-background;
   position: sticky;
@@ -193,7 +193,7 @@ $scrollingAnimationDuration: 0.5s;
 }
 
 @media screen and (max-width: 1024px) {
-  #header {
+  .header {
     .content nav {
       .burgerContainer {
         display: block !important;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -109,8 +109,8 @@ export default function Header({
       <div className={styles.scrollTrigger} ref={trigger as MutableRefObject<HTMLDivElement>} />
       <header
         ref={header as MutableRefObject<HTMLDivElement>}
-        id={styles.header}
-        className={scrolled ? styles.scrolled : ''}>
+        id="header"
+        className={`${styles.header} ${scrolled ? styles.scrolled : ''}`}>
         <div className={styles.content}>
           <Link href="/">
             <img src={logo.src} alt="Logo UA23" />

--- a/src/components/Partners.module.scss
+++ b/src/components/Partners.module.scss
@@ -1,4 +1,4 @@
-#partners {
+.partners {
   display: flex;
   justify-content: space-evenly;
   flex-wrap: wrap;
@@ -12,7 +12,7 @@
 }
 
 @media screen and (max-width: 700px) {
-  #partners {
+  .partners {
     margin: 0 10%;
     padding-bottom: 4rem;
 

--- a/src/components/Partners.tsx
+++ b/src/components/Partners.tsx
@@ -21,7 +21,7 @@ export default function Partners() {
   }, []);
 
   return (
-    <div id={styles.partners}>
+    <div id="partners" className={styles.partners}>
       {!partners || partners.length === 0
         ? 'Chargement des partenaires...'
         : partners?.map((partner: Partner, i: number) => (

--- a/src/components/Wrapper.module.scss
+++ b/src/components/Wrapper.module.scss
@@ -1,11 +1,11 @@
-#loading {
+.loading {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100vh;
 }
 
-#pageContainer {
+.pageContainer {
   min-height: 100vh;
   display: flex;
   justify-content: space-between;

--- a/src/components/Wrapper.tsx
+++ b/src/components/Wrapper.tsx
@@ -185,11 +185,11 @@ export default function Wrapper({
     <>
       <CookieConsent />
       {isLoading || (isDashboard && !isLoggedIn) ? (
-        <main id={styles.loading}>
+        <main id="loading" className={styles.loading}>
           <Loading />
         </main>
       ) : (
-        <div id={styles.pageContainer}>
+        <div id="page-container" className={styles.pageContainer}>
           <Header connected={isLoggedIn} admin={isAdmin} />
           <main>{children}</main>
           <Footer />

--- a/src/components/dashboard/PanelHeader.module.scss
+++ b/src/components/dashboard/PanelHeader.module.scss
@@ -1,6 +1,6 @@
 @import '@/variables.scss';
 
-#panelHeader {
+.panelHeader {
     .header {
       background: url('/images/background.jpg') center no-repeat;
       background-size: cover;

--- a/src/components/dashboard/PanelHeader.tsx
+++ b/src/components/dashboard/PanelHeader.tsx
@@ -15,7 +15,7 @@ const PanelHeader = ({
   /** The title */
   title: string;
 }) => (
-  <div id={styles.panelHeader}>
+  <div id="panel-header" className={styles.panelHeader}>
     <div className={styles.header}>
       <div className={styles.homeTitle}>
         <p>{title}</p>


### PR DESCRIPTION
# Fix ids to give them better name (and make them _actually_ useable)

## Changements

Les ids ont été copiés vers des classNames
Les ids sont maintenant hardcodés dans les TSX.

## Breaking changes

Tout le SCSS qui référence des `#id` et le TSX qui utilise des `styles.<nom d'un id>`

## Ce qu'il reste à faire (POUR LES DRAFTS)

- [x] Vérifier le build
- [x] Lint
- [x] Supprimer les console.log / code commenté
