### PR TITLE
fix: some bugs

### DIFF
--- a/src/app/style.module.scss
+++ b/src/app/style.module.scss
@@ -236,7 +236,6 @@
         font-size: 1.25rem;
         font-weight: 500;
         line-height: 1.5;
-        text-align: justify;
       }
     }
 

--- a/src/app/tournaments/[id]/content.tsx
+++ b/src/app/tournaments/[id]/content.tsx
@@ -66,7 +66,7 @@ export function TournamentInformation({ tournamentId, animate = true }: { tourna
             className={`${styles.boxContainer} ${styles.onTop}`}
             contentClassName={styles.boxContent}>
             {tournament.maxPlayers / tournament.playersPerTeam}{' '}
-            {tournament.playersPerTeam === 1 ? 'équipes' : 'joueurs'}
+            {tournament.playersPerTeam === 1 ? 'joueurs' : 'équipes'}
           </BoxContainer>
           <BoxContainer
             className={styles.boxContainer}

--- a/src/app/tournaments/[id]/style.module.scss
+++ b/src/app/tournaments/[id]/style.module.scss
@@ -43,7 +43,7 @@
         position: absolute;
         left: 80px;
         top: 62px;
-        width: 30rem;
+        width: 31rem;
       }
     }
   }

--- a/src/app/tournaments/content.tsx
+++ b/src/app/tournaments/content.tsx
@@ -6,9 +6,11 @@ import { Icon, Title } from '@/components/UI';
 import Link from 'next/link';
 import Divider from '@/components/UI/Divider';
 import TournamentSwitcherAnimation from '@/components/landing/TournamentSwitcherAnimation';
-import { useAppSelector } from '@/lib/hooks';
+import { useAppDispatch, useAppSelector } from '@/lib/hooks';
 import { getTournamentBackgroundLink, getTournamentImageLink } from '@/utils/uploadLink';
 import { IconName } from '@/components/UI/Icon';
+import { type Action } from '@reduxjs/toolkit';
+import { setLoginModalVisible } from '@/modules/loginModal';
 
 export function TournamentHome({
   animations,
@@ -24,6 +26,7 @@ export function TournamentHome({
   onScrolled?: () => void;
 }) {
   const fadeDuration = animations !== 'none' ? 200 : 0;
+  const dispatch = useAppDispatch();
   const tournaments = useAppSelector((state) => state.tournament.tournaments);
   // This is initialized when tournaments are fetched
   const [selectedTournamentIndex, setSelectedTournamentIndex] = useState(-1);

--- a/src/app/tournaments/content.tsx
+++ b/src/app/tournaments/content.tsx
@@ -268,11 +268,12 @@ export function TournamentHome({
                 Plus d'infos
               </Button>
             </Link>
-            <Link href={`/dashboard`} scroll={false}>
-              <Button className={styles.button} primary>
-                S'inscrire
-              </Button>
-            </Link>
+            <Button
+              className={styles.button}
+              primary
+              onClick={() => dispatch(setLoginModalVisible(true) as unknown as Action)}>
+              S'inscrire
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/UI/TextBlock.module.scss
+++ b/src/components/UI/TextBlock.module.scss
@@ -12,7 +12,6 @@
     font-size: 1.25rem;
     font-weight: 500;
     line-height: 1.5;
-    text-align: justify;
   }
 
   .left {

--- a/src/components/UI/Title.module.scss
+++ b/src/components/UI/Title.module.scss
@@ -32,10 +32,6 @@ $radius: 8px;
     text-align: right;
   }
 
-  &.justify {
-    text-align: justify;
-  }
-
   &.uppercase {
     text-transform: uppercase;
   }

--- a/src/components/UI/Title.tsx
+++ b/src/components/UI/Title.tsx
@@ -23,7 +23,7 @@ const Title = ({
   /** Whether to add a bottom margin to the title component. */
   gutterBottom?: boolean;
   /** The horizontal alignment of the title component. */
-  align?: 'inherit' | 'center' | 'justify' | 'left' | 'right';
+  align?: 'inherit' | 'center' | 'left' | 'right';
   /** An optional class name to apply to the title component. */
   className?: string;
   /** The HTML id attribute to be added to the title component. */


### PR DESCRIPTION
* "équipes" and "joueurs" were mixed in a box container in /tournaments/{id}
* 2 of "Counter strike 2" was alone on its line (/tournaments/{id})
* The register button didn't work in the /tournaments page
* text was justified