### PR TITLE
lint: updated .eslintrc.json so that console calls are now forbidden

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,5 +57,14 @@
     "import/default": "off",
     "@typescript-eslint/no-explicit-any": "warn",
     "@next/next/no-img-element": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": "**/*.tsx",
+      "excludedFiles": "**/*.stories.tsx",
+      "rules": {
+        "no-console": "error"
+      }
+    }
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,7 +63,9 @@
       "files": "**/*.tsx",
       "excludedFiles": "**/*.stories.tsx",
       "rules": {
-        "no-console": "error"
+        "no-console": ["error", {
+          "allow": ["warn", "error"]
+        }]
       }
     }
   ]


### PR DESCRIPTION
* they are still allowed in *.stories.tsx fles

# Update eslint to forbid console.log

## Changes

Forbid use of console commands, except in *.stories.tsx files.
`console.warn` and `console.error` are still useable everywhere.

## Breaking changes

Everywhere where there were console.log