### PR TITLE
feat: now the maximal number of coaches per team is now tournament dependant

### DIFF
--- a/src/app/(dashboard)/dashboard/register/page.tsx
+++ b/src/app/(dashboard)/dashboard/register/page.tsx
@@ -236,7 +236,7 @@ const Register = () => {
                 const tournamentObject = tournaments.find((t) => t.id === tournament)!;
                 if (
                   (userType === 'player' && team.players.length >= tournamentObject.playersPerTeam) ||
-                  (userType === 'coach' && team.coaches.length >= Math.min(tournamentObject.playersPerTeam, 2))
+                  (userType === 'coach' && team.coaches.length >= tournamentObject.coachesPerTeam)
                 ) {
                   setConfirmationForTeam(team);
                 } else {

--- a/src/components/dashboard/TournamentModal.tsx
+++ b/src/components/dashboard/TournamentModal.tsx
@@ -24,6 +24,7 @@ const TournamentModal = ({
   const [name, setName] = useState(tournament?.name || null);
   const [maxPlayers, setMaxPlayers] = useState(tournament?.maxPlayers || null);
   const [playersPerTeam, setPlayersPerTeam] = useState(tournament?.playersPerTeam || null);
+  const [coachesPerTeam, setCoachesPerTeam] = useState(tournament?.coachesPerTeam || null);
   const [infos, setInfos] = useState(tournament?.infos || null);
   const [format, setFormat] = useState(tournament?.format || null);
   const [cashprize, setCashprize] = useState(tournament?.cashprize || null);
@@ -54,6 +55,7 @@ const TournamentModal = ({
                 name: name ?? '',
                 maxPlayers: maxPlayers ?? 0,
                 playersPerTeam: playersPerTeam ?? 0,
+                coachesPerTeam: coachesPerTeam ?? 0,
                 lockedTeamsCount: 0,
                 placesLeft: 0,
                 infos: infos,
@@ -90,6 +92,12 @@ const TournamentModal = ({
           type="number"
           value={playersPerTeam ?? ''}
           onChange={(e) => setPlayersPerTeam(parseInt(e))}
+        />
+        <Input
+          label="Nombre maximal de coachs par équipe"
+          type="number"
+          value={coachesPerTeam ?? ''}
+          onChange={(e) => setCoachesPerTeam(parseInt(e))}
         />
         <Input label="Infos" value={infos ?? ''} onChange={setInfos} />
         <Textarea label="Format" value={format ?? ''} onChange={setFormat} />

--- a/src/modules/admin.ts
+++ b/src/modules/admin.ts
@@ -191,6 +191,7 @@ export const updateTournament =
         name: tournament.name,
         maxPlayers: tournament.maxPlayers,
         playersPerTeam: tournament.playersPerTeam,
+        coachesPerTeam: tournament.coachesPerTeam,
         display: tournament.display.toString(),
         displayCasters: tournament.displayCasters.toString(),
         displayCashprize: tournament.displayCashprize.toString(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,7 @@ export interface Tournament {
   name: string;
   maxPlayers: number;
   playersPerTeam: number;
+  coachesPerTeam: number;
   lockedTeamsCount: number;
   placesLeft: number;
   infos: string | null;


### PR DESCRIPTION
# Takes into account that the maximal number of coaches is now determined by a field given by the api

# Changes

We no longer care about the number of players per team of the tournament to deduce the maximum number of coaches
Admin can now modify the maximum number of coaches on a per-tournament basis (wait, is the syntax of this sentence right ??)