### PR TITLE
fix: now coords have special names in the trombi

### DIFF
--- a/src/app/(dashboard)/admin/badge/page.tsx
+++ b/src/app/(dashboard)/admin/badge/page.tsx
@@ -203,7 +203,7 @@ export default function BadgePage() {
           </Title>
           {user!.orga!.roles.length > 0 ? (
             <TeamMember
-              color={user!.orga!.roles[roleToPreview].commission.color}
+              commission={user!.orga!.roles[roleToPreview].commission}
               member={{
                 ...user!,
                 name: displayName ? user?.firstname + ' ' + user?.lastname : undefined,

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -59,10 +59,10 @@ const About = () => {
                       {commission.name}
                     </Title>
                     {commission.roles.respo.map((orga) => (
-                      <TeamMember member={orga} color={commission.color} role={'respo'} key={orga.id} />
+                      <TeamMember member={orga} commission={commission} role={'respo'} key={orga.id} />
                     ))}
                     {commission.roles.member.map((orga) => (
-                      <TeamMember member={orga} color={commission.color} role={'member'} key={orga.id} />
+                      <TeamMember member={orga} commission={commission} role={'member'} key={orga.id} />
                     ))}
                   </div>
                 ))}

--- a/src/components/landing/TeamMember.stories.tsx
+++ b/src/components/landing/TeamMember.stories.tsx
@@ -13,7 +13,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     member: { id: 'ABCDEF', name: 'Jean Dupont', username: 'superjean' },
-    color: '#FF0000',
+    commission: { id: 'dev', name: 'Développement', nameOnBadge: 'Développement', color: '#FF0000' },
     role: 'member',
   },
 };
@@ -21,8 +21,16 @@ export const Default: Story = {
 export const WithGivenImage: Story = {
   args: {
     member: { id: 'ABCDEF', name: 'Jean Dupont', username: 'superjean' },
-    color: '#FF0000',
+    commission: { id: 'dev', name: 'Développement', nameOnBadge: 'Développement', color: '#FF0000' },
     role: 'member',
     image: 'https://picsum.photos/200',
+  },
+};
+
+export const ForCoordOrga: Story = {
+  args: {
+    member: { id: 'ABCDEF', name: 'Jean Dupont', username: 'superjean' },
+    commission: { id: 'coord', name: 'Coordinateur', nameOnBadge: 'Coordinateur', color: '#FF0000' },
+    role: 'member',
   },
 };

--- a/src/components/landing/TeamMember.tsx
+++ b/src/components/landing/TeamMember.tsx
@@ -1,25 +1,31 @@
 import styles from './TeamMember.module.scss';
 import { uploadsUrl } from '@/utils/environment';
-import { Orga } from '@/types';
+import { Commission, Orga } from '@/types';
 import defaultImage from '@/../public/images/logo.webp';
 
 export default function TeamMember({
   member,
   role,
-  color,
+  commission,
   image,
 }: {
   /** The user to display. */
   member: Orga;
   /** Which role the user has, in the commission we are rendering this component for. */
   role: 'respo' | 'member';
-  /** The color that represents the commission we are rendering. */
-  color: string;
+  /** The commission that is represented. */
+  commission: Commission;
   /** The image of the user. If no image is given, it will take the image at the default link. */
   image?: string;
 }) {
+  let roleDisplayed = '';
+  if (commission.id === 'coord') {
+    roleDisplayed = role === 'respo' ? 'Présidente' : 'Coordinateur.e';
+  } else {
+    roleDisplayed = role === 'respo' ? 'Responsable' : 'Membre';
+  }
   return (
-    <div className={styles.member} style={{ '--team-color': color } as React.CSSProperties}>
+    <div className={styles.member} style={{ '--team-color': commission.color } as React.CSSProperties}>
       <div className={styles.imgContainer}>
         <div className={styles.imageFont}></div>
         <div className={styles.imageBackground}>
@@ -34,7 +40,7 @@ export default function TeamMember({
       </div>
       {member.name && <span>{member.name}</span>}
       {member.username && <span>{member.username}</span>}
-      <span className={styles.role}>{role === 'respo' ? 'Responsable' : 'Membre'}</span>
+      <span className={styles.role}>{roleDisplayed}</span>
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,7 +262,7 @@ export interface Commission {
   name: string;
   nameOnBadge: string;
   color: string;
-  masterCommission: string;
+  masterCommission?: string;
 }
 
 export type CommissionRole = 'respo' | 'member';


### PR DESCRIPTION
# In the trombi, for coords, it's now displaying roles "Présidente" and "Coordinateur.e"